### PR TITLE
replaces id generated by random uuid with new ObjectId().toString()

### DIFF
--- a/src/main/java/de/taimos/dao/AEntity.java
+++ b/src/main/java/de/taimos/dao/AEntity.java
@@ -11,14 +11,13 @@ package de.taimos.dao;
  * and limitations under the License. #L%
  */
 
-import java.util.UUID;
-
+import org.bson.types.ObjectId;
 import org.jongo.marshall.jackson.oid.Id;
 
 public abstract class AEntity {
 	
 	@Id
-	protected String id = UUID.randomUUID().toString();
+	protected String id = new ObjectId().toString();
 	
 	
 	public String getId() {


### PR DESCRIPTION
UUID is too long and prevents deletion of a document form the database

see:

de.taimos.dao.mongo.AbstractMongoDAO.delete(String)
and
http://docs.mongodb.org/manual/reference/object-id/

The problem still exists, when setting the id manually with a value not conforming to a ObjectId.
